### PR TITLE
fix: ignore VPC IPv6 assignment drift after create

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -35,7 +35,7 @@ resource "aws_vpc" "this" {
   # Instance tenancy - dedicated for compliance requirements, default for cost efficiency
   instance_tenancy = var.instance_tenancy
 
-  # IPv6 configuration
+  # IPv6 configuration (applied at create; later flips are ignored — see lifecycle)
   assign_generated_ipv6_cidr_block = var.assign_generated_ipv6_cidr_block
 
   # Additional DNS settings
@@ -47,6 +47,19 @@ resource "aws_vpc" "this" {
     },
     var.tags
   )
+
+  # Keep existing AWS-assigned IPv6 CIDRs as-is when config later sets
+  # assign_generated_ipv6_cidr_block=false (or omits it). Avoids stripping
+  # dual-stack VPC CIDRs without also managing subnet IPv6 / EIGW.
+  # To intentionally change IPv6 assignment, use AWS CLI/console or -replace.
+  lifecycle {
+    ignore_changes = [
+      assign_generated_ipv6_cidr_block,
+      ipv6_association_id,
+      ipv6_cidr_block,
+      ipv6_cidr_block_network_border_group,
+    ]
+  }
 }
 
 

--- a/variables.tf
+++ b/variables.tf
@@ -35,7 +35,7 @@ variable "instance_tenancy" {
 }
 
 variable "assign_generated_ipv6_cidr_block" {
-  description = "Whether to assign AWS-generated IPv6 CIDR block to VPC and subnets. Note: Changing from true to false requires manually removing IPv6 CIDR blocks from all subnets first before applying."
+  description = "Whether to assign AWS-generated IPv6 CIDR block to VPC and subnets at create time. Later changes are ignored on aws_vpc (lifecycle) so existing IPv6 CIDRs are not stripped; set true at create (or use -replace/CLI) to enable dual-stack."
   type        = bool
   default     = false
 }


### PR DESCRIPTION
## Summary
- Ignore `assign_generated_ipv6_cidr_block` / related computed IPv6 attrs on `aws_vpc` after create
- Clears false drift that would strip existing VPC IPv6 CIDRs (or force unfinished dual-stack)

Closes #68

## Test plan
- [ ] CI green
- [ ] Existing VPC with IPv6 + `assign_generated_ipv6_cidr_block = false` → no VPC ipv6 plan changes