### PR TITLE
fix: drop computed attrs from VPC IPv6 ignore_changes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -55,9 +55,6 @@ resource "aws_vpc" "this" {
   lifecycle {
     ignore_changes = [
       assign_generated_ipv6_cidr_block,
-      ipv6_association_id,
-      ipv6_cidr_block,
-      ipv6_cidr_block_network_border_group,
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Keep only `assign_generated_ipv6_cidr_block` in `ignore_changes` to silence Terraform warnings

Closes #70

## Test plan
- [ ] CI green / plan no longer warns about redundant ignore_changes