### PR TITLE
fix: decouple VPC IPv6 CIDR from dual-stack networking

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,6 +22,9 @@ locals {
   ipv6_prefix_offset_private  = length(var.public_subnet_cidrs)
   ipv6_prefix_offset_isolated = length(var.public_subnet_cidrs) + length(var.private_subnet_cidrs)
   ipv6_prefix_offset_database = length(var.public_subnet_cidrs) + length(var.private_subnet_cidrs) + length(var.isolated_subnet_cidrs)
+
+  # Dual-stack networking (subnets/EIGW/routes/NACLs) is optional even when the VPC has IPv6
+  enable_ipv6_networking = coalesce(var.enable_ipv6_networking, var.assign_generated_ipv6_cidr_block)
 }
 
 # ===================================
@@ -35,7 +38,7 @@ resource "aws_vpc" "this" {
   # Instance tenancy - dedicated for compliance requirements, default for cost efficiency
   instance_tenancy = var.instance_tenancy
 
-  # IPv6 configuration (applied at create; later flips are ignored — see lifecycle)
+  # IPv6 configuration (VPC CIDR only; subnet/EIGW/routes use enable_ipv6_networking)
   assign_generated_ipv6_cidr_block = var.assign_generated_ipv6_cidr_block
 
   # Additional DNS settings
@@ -47,16 +50,6 @@ resource "aws_vpc" "this" {
     },
     var.tags
   )
-
-  # Keep existing AWS-assigned IPv6 CIDRs as-is when config later sets
-  # assign_generated_ipv6_cidr_block=false (or omits it). Avoids stripping
-  # dual-stack VPC CIDRs without also managing subnet IPv6 / EIGW.
-  # To intentionally change IPv6 assignment, use AWS CLI/console or -replace.
-  lifecycle {
-    ignore_changes = [
-      assign_generated_ipv6_cidr_block,
-    ]
-  }
 }
 
 
@@ -126,8 +119,8 @@ resource "aws_subnet" "public" {
   map_public_ip_on_launch = true
 
   # IPv6 configuration
-  ipv6_cidr_block                 = var.assign_generated_ipv6_cidr_block && aws_vpc.this.ipv6_cidr_block != null ? cidrsubnet(aws_vpc.this.ipv6_cidr_block, 8, local.ipv6_prefix_offset_public + count.index) : null
-  assign_ipv6_address_on_creation = var.assign_generated_ipv6_cidr_block && aws_vpc.this.ipv6_cidr_block != null ? true : false
+  ipv6_cidr_block                 = local.enable_ipv6_networking && aws_vpc.this.ipv6_cidr_block != null ? cidrsubnet(aws_vpc.this.ipv6_cidr_block, 8, local.ipv6_prefix_offset_public + count.index) : null
+  assign_ipv6_address_on_creation = local.enable_ipv6_networking && aws_vpc.this.ipv6_cidr_block != null ? true : false
 
   tags = merge(
     {
@@ -169,7 +162,7 @@ resource "aws_route_table" "public" {
   }
 
   dynamic "route" {
-    for_each = var.assign_generated_ipv6_cidr_block && var.create_igw && !try(var.custom_routes.public.use_only, false) && length(var.public_subnet_cidrs) > 0 ? [1] : []
+    for_each = local.enable_ipv6_networking && var.create_igw && !try(var.custom_routes.public.use_only, false) && length(var.public_subnet_cidrs) > 0 ? [1] : []
     content {
       ipv6_cidr_block = "::/0"
       gateway_id      = aws_internet_gateway.this[0].id
@@ -204,8 +197,8 @@ resource "aws_subnet" "private" {
   availability_zone = var.availability_zones[count.index]
 
   # IPv6 configuration
-  ipv6_cidr_block                 = var.assign_generated_ipv6_cidr_block && aws_vpc.this.ipv6_cidr_block != null ? cidrsubnet(aws_vpc.this.ipv6_cidr_block, 8, local.ipv6_prefix_offset_private + count.index) : null
-  assign_ipv6_address_on_creation = var.assign_generated_ipv6_cidr_block && aws_vpc.this.ipv6_cidr_block != null ? true : false
+  ipv6_cidr_block                 = local.enable_ipv6_networking && aws_vpc.this.ipv6_cidr_block != null ? cidrsubnet(aws_vpc.this.ipv6_cidr_block, 8, local.ipv6_prefix_offset_private + count.index) : null
+  assign_ipv6_address_on_creation = local.enable_ipv6_networking && aws_vpc.this.ipv6_cidr_block != null ? true : false
 
   tags = merge(
     {
@@ -246,7 +239,7 @@ resource "aws_route_table" "private" {
   }
 
   dynamic "route" {
-    for_each = var.assign_generated_ipv6_cidr_block && var.enable_route_tables && length(var.private_subnet_cidrs) > 0 ? [1] : []
+    for_each = local.enable_ipv6_networking && var.enable_route_tables && length(var.private_subnet_cidrs) > 0 ? [1] : []
     content {
       ipv6_cidr_block        = "::/0"
       egress_only_gateway_id = aws_egress_only_internet_gateway.this[0].id
@@ -281,8 +274,8 @@ resource "aws_subnet" "isolated" {
   availability_zone = var.availability_zones[count.index]
 
   # IPv6 configuration
-  ipv6_cidr_block                 = var.assign_generated_ipv6_cidr_block && aws_vpc.this.ipv6_cidr_block != null ? cidrsubnet(aws_vpc.this.ipv6_cidr_block, 8, local.ipv6_prefix_offset_isolated + count.index) : null
-  assign_ipv6_address_on_creation = var.assign_generated_ipv6_cidr_block && aws_vpc.this.ipv6_cidr_block != null ? true : false
+  ipv6_cidr_block                 = local.enable_ipv6_networking && aws_vpc.this.ipv6_cidr_block != null ? cidrsubnet(aws_vpc.this.ipv6_cidr_block, 8, local.ipv6_prefix_offset_isolated + count.index) : null
+  assign_ipv6_address_on_creation = local.enable_ipv6_networking && aws_vpc.this.ipv6_cidr_block != null ? true : false
 
   tags = merge(
     {
@@ -341,8 +334,8 @@ resource "aws_subnet" "database" {
   availability_zone = var.availability_zones[count.index]
 
   # IPv6 configuration
-  ipv6_cidr_block                 = var.assign_generated_ipv6_cidr_block && aws_vpc.this.ipv6_cidr_block != null ? cidrsubnet(aws_vpc.this.ipv6_cidr_block, 8, local.ipv6_prefix_offset_database + count.index) : null
-  assign_ipv6_address_on_creation = var.assign_generated_ipv6_cidr_block && aws_vpc.this.ipv6_cidr_block != null ? true : false
+  ipv6_cidr_block                 = local.enable_ipv6_networking && aws_vpc.this.ipv6_cidr_block != null ? cidrsubnet(aws_vpc.this.ipv6_cidr_block, 8, local.ipv6_prefix_offset_database + count.index) : null
+  assign_ipv6_address_on_creation = local.enable_ipv6_networking && aws_vpc.this.ipv6_cidr_block != null ? true : false
 
   tags = merge(
     {
@@ -394,7 +387,7 @@ resource "aws_route_table_association" "database" {
 # Egress-Only Internet Gateway (for IPv6)
 # ===================================
 resource "aws_egress_only_internet_gateway" "this" {
-  count  = var.assign_generated_ipv6_cidr_block && length(var.private_subnet_cidrs) > 0 ? 1 : 0
+  count  = local.enable_ipv6_networking && length(var.private_subnet_cidrs) > 0 ? 1 : 0
   vpc_id = aws_vpc.this.id
 
   tags = merge(

--- a/network_acls.tf
+++ b/network_acls.tf
@@ -119,7 +119,7 @@ resource "aws_network_acl_rule" "public_egress_all" {
 }
 
 resource "aws_network_acl_rule" "public_ingress_ipv6_vpc" {
-  count = var.enable_nacls && length(var.public_subnet_cidrs) > 0 && var.assign_generated_ipv6_cidr_block ? 1 : 0
+  count = var.enable_nacls && length(var.public_subnet_cidrs) > 0 && local.enable_ipv6_networking ? 1 : 0
 
   network_acl_id  = aws_network_acl.public[0].id
   rule_number     = 300
@@ -131,7 +131,7 @@ resource "aws_network_acl_rule" "public_ingress_ipv6_vpc" {
 }
 
 resource "aws_network_acl_rule" "public_ingress_ipv6_all" {
-  count = var.enable_nacls && length(var.public_subnet_cidrs) > 0 && var.assign_generated_ipv6_cidr_block ? 1 : 0
+  count = var.enable_nacls && length(var.public_subnet_cidrs) > 0 && local.enable_ipv6_networking ? 1 : 0
 
   network_acl_id  = aws_network_acl.public[0].id
   rule_number     = 400
@@ -143,7 +143,7 @@ resource "aws_network_acl_rule" "public_ingress_ipv6_all" {
 }
 
 resource "aws_network_acl_rule" "public_egress_ipv6_all" {
-  count = var.enable_nacls && length(var.public_subnet_cidrs) > 0 && var.assign_generated_ipv6_cidr_block ? 1 : 0
+  count = var.enable_nacls && length(var.public_subnet_cidrs) > 0 && local.enable_ipv6_networking ? 1 : 0
 
   network_acl_id  = aws_network_acl.public[0].id
   rule_number     = 200
@@ -209,7 +209,7 @@ resource "aws_network_acl_rule" "private_egress_all" {
 }
 
 resource "aws_network_acl_rule" "private_ingress_ipv6_vpc" {
-  count = var.enable_nacls && length(var.private_subnet_cidrs) > 0 && var.assign_generated_ipv6_cidr_block ? 1 : 0
+  count = var.enable_nacls && length(var.private_subnet_cidrs) > 0 && local.enable_ipv6_networking ? 1 : 0
 
   network_acl_id  = aws_network_acl.private[0].id
   rule_number     = 300
@@ -221,7 +221,7 @@ resource "aws_network_acl_rule" "private_ingress_ipv6_vpc" {
 }
 
 resource "aws_network_acl_rule" "private_ingress_ipv6_all" {
-  count = var.enable_nacls && length(var.private_subnet_cidrs) > 0 && var.assign_generated_ipv6_cidr_block ? 1 : 0
+  count = var.enable_nacls && length(var.private_subnet_cidrs) > 0 && local.enable_ipv6_networking ? 1 : 0
 
   network_acl_id  = aws_network_acl.private[0].id
   rule_number     = 400
@@ -233,7 +233,7 @@ resource "aws_network_acl_rule" "private_ingress_ipv6_all" {
 }
 
 resource "aws_network_acl_rule" "private_egress_ipv6_all" {
-  count = var.enable_nacls && length(var.private_subnet_cidrs) > 0 && var.assign_generated_ipv6_cidr_block ? 1 : 0
+  count = var.enable_nacls && length(var.private_subnet_cidrs) > 0 && local.enable_ipv6_networking ? 1 : 0
 
   network_acl_id  = aws_network_acl.private[0].id
   rule_number     = 200
@@ -275,7 +275,7 @@ resource "aws_network_acl_rule" "isolated_egress_vpc" {
 }
 
 resource "aws_network_acl_rule" "isolated_ingress_ipv6_vpc" {
-  count = var.enable_nacls && length(var.isolated_subnet_cidrs) > 0 && var.assign_generated_ipv6_cidr_block ? 1 : 0
+  count = var.enable_nacls && length(var.isolated_subnet_cidrs) > 0 && local.enable_ipv6_networking ? 1 : 0
 
   network_acl_id  = aws_network_acl.isolated[0].id
   rule_number     = 200
@@ -287,7 +287,7 @@ resource "aws_network_acl_rule" "isolated_ingress_ipv6_vpc" {
 }
 
 resource "aws_network_acl_rule" "isolated_egress_ipv6_vpc" {
-  count = var.enable_nacls && length(var.isolated_subnet_cidrs) > 0 && var.assign_generated_ipv6_cidr_block ? 1 : 0
+  count = var.enable_nacls && length(var.isolated_subnet_cidrs) > 0 && local.enable_ipv6_networking ? 1 : 0
 
   network_acl_id  = aws_network_acl.isolated[0].id
   rule_number     = 200
@@ -354,7 +354,7 @@ resource "aws_network_acl_rule" "database_egress_all" {
 }
 
 resource "aws_network_acl_rule" "database_ingress_ipv6_vpc" {
-  count = var.enable_nacls && length(var.database_subnet_cidrs) > 0 && var.assign_generated_ipv6_cidr_block ? 1 : 0
+  count = var.enable_nacls && length(var.database_subnet_cidrs) > 0 && local.enable_ipv6_networking ? 1 : 0
 
   network_acl_id  = aws_network_acl.database[0].id
   rule_number     = 200
@@ -366,7 +366,7 @@ resource "aws_network_acl_rule" "database_ingress_ipv6_vpc" {
 }
 
 resource "aws_network_acl_rule" "database_ingress_ipv6_all" {
-  count = var.enable_nacls && length(var.database_subnet_cidrs) > 0 && var.assign_generated_ipv6_cidr_block ? 1 : 0
+  count = var.enable_nacls && length(var.database_subnet_cidrs) > 0 && local.enable_ipv6_networking ? 1 : 0
 
   network_acl_id  = aws_network_acl.database[0].id
   rule_number     = 250
@@ -378,7 +378,7 @@ resource "aws_network_acl_rule" "database_ingress_ipv6_all" {
 }
 
 resource "aws_network_acl_rule" "database_egress_ipv6_vpc" {
-  count = var.enable_nacls && length(var.database_subnet_cidrs) > 0 && var.assign_generated_ipv6_cidr_block ? 1 : 0
+  count = var.enable_nacls && length(var.database_subnet_cidrs) > 0 && local.enable_ipv6_networking ? 1 : 0
 
   network_acl_id  = aws_network_acl.database[0].id
   rule_number     = 200
@@ -391,7 +391,7 @@ resource "aws_network_acl_rule" "database_egress_ipv6_vpc" {
 }
 
 resource "aws_network_acl_rule" "database_egress_ipv6_all" {
-  count = var.enable_nacls && length(var.database_subnet_cidrs) > 0 && var.assign_generated_ipv6_cidr_block ? 1 : 0
+  count = var.enable_nacls && length(var.database_subnet_cidrs) > 0 && local.enable_ipv6_networking ? 1 : 0
 
   network_acl_id  = aws_network_acl.database[0].id
   rule_number     = 250

--- a/outputs.tf
+++ b/outputs.tf
@@ -25,7 +25,7 @@ output "internet_gateway_id" {
 
 output "egress_only_internet_gateway_id" {
   description = "The ID of the Egress-Only Internet Gateway (for IPv6)"
-  value       = var.assign_generated_ipv6_cidr_block ? try(aws_egress_only_internet_gateway.this[0].id, null) : null
+  value       = local.enable_ipv6_networking ? try(aws_egress_only_internet_gateway.this[0].id, null) : null
 }
 
 output "isolated_route_table_ids" {
@@ -172,20 +172,20 @@ output "vpc_ipv6_cidr" {
 
 output "public_subnet_ipv6_cidrs" {
   description = "List of IPv6 CIDR blocks for public subnets"
-  value       = var.assign_generated_ipv6_cidr_block ? [for subnet in aws_subnet.public : subnet.ipv6_cidr_block] : []
+  value       = local.enable_ipv6_networking ? [for subnet in aws_subnet.public : subnet.ipv6_cidr_block] : []
 }
 
 output "private_subnet_ipv6_cidrs" {
   description = "List of IPv6 CIDR blocks for private subnets"
-  value       = var.assign_generated_ipv6_cidr_block ? [for subnet in aws_subnet.private : subnet.ipv6_cidr_block] : []
+  value       = local.enable_ipv6_networking ? [for subnet in aws_subnet.private : subnet.ipv6_cidr_block] : []
 }
 
 output "isolated_subnet_ipv6_cidrs" {
   description = "List of IPv6 CIDR blocks for isolated subnets"
-  value       = var.assign_generated_ipv6_cidr_block ? [for subnet in aws_subnet.isolated : subnet.ipv6_cidr_block] : []
+  value       = local.enable_ipv6_networking ? [for subnet in aws_subnet.isolated : subnet.ipv6_cidr_block] : []
 }
 
 output "database_subnet_ipv6_cidrs" {
   description = "List of IPv6 CIDR blocks for database subnets"
-  value       = var.assign_generated_ipv6_cidr_block ? [for subnet in aws_subnet.database : subnet.ipv6_cidr_block] : []
+  value       = local.enable_ipv6_networking ? [for subnet in aws_subnet.database : subnet.ipv6_cidr_block] : []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -35,9 +35,16 @@ variable "instance_tenancy" {
 }
 
 variable "assign_generated_ipv6_cidr_block" {
-  description = "Whether to assign AWS-generated IPv6 CIDR block to VPC and subnets at create time. Later changes are ignored on aws_vpc (lifecycle) so existing IPv6 CIDRs are not stripped; set true at create (or use -replace/CLI) to enable dual-stack."
+  description = "Whether to assign an AWS-generated IPv6 CIDR block to the VPC."
   type        = bool
   default     = false
+}
+
+variable "enable_ipv6_networking" {
+  description = "Enable IPv6 on subnets (CIDRs + assign_ipv6_address_on_creation), egress-only IGW, IPv6 routes, and IPv6 NACL rules. Defaults to assign_generated_ipv6_cidr_block for backward compatibility. Set false to keep a VPC IPv6 CIDR without enabling dual-stack networking."
+  type        = bool
+  default     = null
+  nullable    = true
 }
 
 variable "enable_dns_hostnames" {


### PR DESCRIPTION
## Summary
- Revert `ignore_changes` on VPC IPv6 (that was drift-satisfaction, not a real design)
- Add `enable_ipv6_networking` for subnets/EIGW/routes/IPv6 NACLs; defaults to `assign_generated_ipv6_cidr_block`
- VPC IPv6 CIDR stays controlled only by `assign_generated_ipv6_cidr_block`

Closes #72

## Test plan
- [ ] Existing dual-stack callers unchanged (default coalesce)
- [ ] `assign_generated_ipv6_cidr_block=true` + `enable_ipv6_networking=false` → no subnet/EIGW plan when VPC already has IPv6